### PR TITLE
9 improve yolo tracking to distinguish cyclist from person and cycle

### DIFF
--- a/helper_script.py
+++ b/helper_script.py
@@ -426,15 +426,15 @@ class Youtube_Helper:
         """
         Draw YOLO-style bounding boxes on a video and save the annotated output.
 
-        This method takes a DataFrame containing normalized bounding box coordinates (in YOLO format),
+        This method takes a DataFrame containing normalised bounding box coordinates (in YOLO format),
         matches them frame-by-frame to the input video, draws the corresponding boxes and labels,
         and writes the resulting video to disk.
 
         Args:
             df (pd.DataFrame): DataFrame containing at least the following columns:
                 - 'Frame Count': Original frame indices in the source video.
-                - 'X-center', 'Y-center': Normalized center coordinates (0 to 1).
-                - 'Width', 'Height': Normalized width and height (0 to 1).
+                - 'X-center', 'Y-center': Normalised center coordinates (0 to 1).
+                - 'Width', 'Height': Normalised width and height (0 to 1).
                 - 'Unique Id': Identifier to display in the label.
             fps (float): Frames per second for the output video.
             video_path (str): Path to the input video file.
@@ -481,7 +481,7 @@ class Youtube_Helper:
             frame_data = df[df["Frame Index"] == frame_index]
 
             for _, row in frame_data.iterrows():
-                # Convert normalized coordinates to absolute pixel values
+                # Convert normalised coordinates to absolute pixel values
                 x_center = row["X-center"] * width
                 y_center = row["Y-center"] * height
                 w = row["Width"] * width
@@ -1125,7 +1125,7 @@ class Youtube_Helper:
 
         Process:
             - Updates tracker YAML if custom config is detected.
-            - Initializes YOLO tracking and/or segmentation models.
+            - Initialises YOLO tracking and/or segmentation models.
             - Sets up directories for outputs (frames, labels, tracked images, videos).
             - Processes each frame of the input video:
                 * Runs YOLO tracking (detection and/or segmentation mode).
@@ -1186,7 +1186,7 @@ class Youtube_Helper:
             os.makedirs(seg_annotated_frame_output_path, exist_ok=True)
             os.makedirs(seg_tracked_frame_output_path, exist_ok=True)
 
-        # Initialize video writers for displaying tracking/segmentation results
+        # Initialise video writers for displaying tracking/segmentation results
         fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # type: ignore
 
         if bbox_mode and display_frame_tracking:

--- a/helper_script.py
+++ b/helper_script.py
@@ -422,6 +422,91 @@ class Youtube_Helper:
         # Close the video clip to release any resources used.
         video_clip.close()
 
+    def draw_yolo_boxes_on_video(self, df, fps, video_path, output_path):
+        """
+        Draw YOLO-style bounding boxes on a video and save the annotated output.
+
+        This method takes a DataFrame containing normalized bounding box coordinates (in YOLO format),
+        matches them frame-by-frame to the input video, draws the corresponding boxes and labels,
+        and writes the resulting video to disk.
+
+        Args:
+            df (pd.DataFrame): DataFrame containing at least the following columns:
+                - 'Frame Count': Original frame indices in the source video.
+                - 'X-center', 'Y-center': Normalized center coordinates (0 to 1).
+                - 'Width', 'Height': Normalized width and height (0 to 1).
+                - 'Unique Id': Identifier to display in the label.
+            fps (float): Frames per second for the output video.
+            video_path (str): Path to the input video file.
+            output_path (str): Path to save the annotated output video.
+
+        Raises:
+            IOError: If the input video cannot be opened.
+        """
+
+        # Ensure the output directory exists
+        output_dir = os.path.dirname(output_path)
+        if output_dir and not os.path.exists(output_dir):
+            os.makedirs(output_dir, exist_ok=True)
+
+        # Normalise frame indices to start from 0
+        min_frame = df["Frame Count"].min()
+        df["Frame Index"] = df["Frame Count"] - min_frame
+
+        # Attempt to open the input video
+        cap = cv2.VideoCapture(video_path)
+        if not cap.isOpened():
+            raise IOError(f"Cannot open video file: {video_path}")
+
+        # Get video dimensions and total number of frames
+        width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+
+        # Set up video writer with the same resolution and specified fps
+        fourcc = cv2.VideoWriter_fourcc(*'mp4v')  # type: ignore
+        out = cv2.VideoWriter(output_path, fourcc, fps, (width, height))
+        logger.info(f"Writing to {output_path} ({width}x{height} @ {fps}fps)")
+
+        frame_index = 0
+
+        # Process each frame
+        while frame_index < total_frames:
+            success, frame = cap.read()
+            if not success:
+                logger.error(f"Failed to read frame {frame_index}")
+                break
+
+            # Filter YOLO data for this adjusted frame index
+            frame_data = df[df["Frame Index"] == frame_index]
+
+            for _, row in frame_data.iterrows():
+                # Convert normalized coordinates to absolute pixel values
+                x_center = row["X-center"] * width
+                y_center = row["Y-center"] * height
+                w = row["Width"] * width
+                h = row["Height"] * height
+
+                # Calculate top-left and bottom-right corners of the box
+                x1 = int(x_center - w / 2)
+                y1 = int(y_center - h / 2)
+                x2 = int(x_center + w / 2)
+                y2 = int(y_center + h / 2)
+
+                # Draw rectangle and label with unique ID
+                cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+                label = f"ID: {int(row['Unique Id'])}"
+                cv2.putText(frame, label, (x1, max(y1 - 10, 0)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 2)
+
+            # Write the modified frame to the output video
+            out.write(frame)
+            frame_index += 1
+
+        # Release video objects
+        cap.release()
+        out.release()
+
     @staticmethod
     def detect_gpu():
         """
@@ -806,25 +891,12 @@ class Youtube_Helper:
         except KeyError:
             return "Unknown"
 
-    @staticmethod
-    def update_csv_with_fps(df):
+    def update_csv_with_fps(self, df):
         """
         Updates the existing CSV file by adding/updating the 'fps_list' column
         with the FPS values for each video's IDs from local files.
         If the file does not exist, the previous FPS value is kept.
         """
-        def get_local_fps(video_file):
-            file_path = os.path.join("videos", f"{video_file}.mp4")
-            if not os.path.isfile(file_path):
-                logger.warning(f"File not found: {file_path}")
-                return None
-            cap = cv2.VideoCapture(file_path)
-            if not cap.isOpened():
-                logger.error(f"Could not open file: {file_path}")
-                return None
-            fps = cap.get(cv2.CAP_PROP_FPS)
-            cap.release()
-            return fps if fps > 0 else None
 
         def process_videos(video_ids_str, existing_fps_list_str):
             # Parse video IDs (e.g., '["videos_1", "videos_2"]')
@@ -848,7 +920,7 @@ class Youtube_Helper:
 
             updated_fps_list = []
             for i, video_id in enumerate(video_ids):
-                fps = get_local_fps(video_id)
+                fps = self.get_video_fps(video_id)
                 if fps is not None:
                     updated_fps_list.append(fps)
                 else:

--- a/utils/algorithms.py
+++ b/utils/algorithms.py
@@ -306,7 +306,7 @@ class Algorithms():
             df (pd.DataFrame): YOLO detections DataFrame containing columns:
                 'YOLO_id' (class, 0=person, 1=bicycle, 3=motorcycle), 'Unique Id',
                 'Frame Count', 'X-center', 'Y-center', 'Width', 'Height'.
-            id (int or str): The Unique Id of the person to analyze.
+            id (int or str): The Unique Id of the person to analyse.
             avg_height (float): The average real-world height of the person (cm).
             min_shared_frames (int, optional): Minimum number of frames with both the person and vehicle
                 present for comparison. Defaults to 5.

--- a/utils/algorithms.py
+++ b/utils/algorithms.py
@@ -115,6 +115,7 @@ class Algorithms():
                 long = result[7]
                 avg_height = result[15]
                 iso3 = result[16]
+                fps = result[17]
 
                 # value = dfs.get(key)  # Get corresponding YOLO data
 
@@ -128,7 +129,7 @@ class Algorithms():
                 # Loop through each individual's crossing data in this video
                 for id, time in id_time.items():
 
-                    if self.is_rider_id(df, id, key, avg_height):
+                    if self.is_rider_id(df, id, key, avg_height, fps):
                         continue  # Skip rider, not a pedestrian
 
                     # Get all frames for this person
@@ -290,7 +291,7 @@ class Algorithms():
 
         return avg_over_time
 
-    def is_rider_id(self, df, id, key, avg_height, min_shared_frames=5,
+    def is_rider_id(self, df, id, key, avg_height, fps, min_shared_frames=5,
                     dist_thresh=80, similarity_thresh=0.8, overlap_ratio=0.7):
         """
         Determines if a person identified by the given Unique Id is riding a bicycle or motorcycle
@@ -417,7 +418,6 @@ class Algorithms():
                 # Check if the result is None (i.e., no matching data was found)
                 if result is not None:
                     # Unpack the result since it's not None
-                    fps = 24
 
                     first_time = first_frame / fps
                     last_time = last_frame / fps

--- a/utils/values.py
+++ b/utils/values.py
@@ -40,6 +40,7 @@ class Values():
                 - Literacy rate
                 - Average height
                 - ISO-3 code for country
+                - Fps of the video
         """
         id, start_ = key.rsplit("_", 1)  # Splitting the key into video ID and start time
 


### PR DESCRIPTION
## Problem

When using YOLO for tracking, a cyclist (person riding a bicycle) was often detected as two separate objects: a `person` and a `cycle`. This caused misleading speed calculations, because both bounding boxes moved together and were assigned the same speed, resulting in inflated analytics and inaccurate tracking of pedestrian.

## Solution

This PR implements logic to **filter out all `person` and `cycle` or `motorcyclist` detections whose bounding boxes overlap and move with the same speed**, treating them as a single cyclist rather than two independent objects. This is achieved by:

- Checking proximity and movement similarity between `person` and `cycle` or `motorcyclist` tracks across shared frames.
- Marking and filtering tracks that correspond to the same real-world cyclist, to prevent counting.
- Only keeping detections where `person` and `cycle` or `motorcyclist` are genuinely moving independently.

## Impact

- Prevents inflated speed analytics caused by correlated bounding boxes.
- Improves the accuracy of pedestrian tracking in analytics and reports.

## Additional Context

- Relevant YOLO version: 11
- Closes #9
